### PR TITLE
Improve integration with Interpolations

### DIFF
--- a/src/CenterIndexedArrays.jl
+++ b/src/CenterIndexedArrays.jl
@@ -97,6 +97,7 @@ function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{CenterIndex
 end
 
 Base.parent(A::CenterIndexedArray) = A.data
+Interpolations.popwrapper(A::CenterIndexedArray) = parent(A)
 
 function Base.showarg(io::IO, A::CenterIndexedArray, toplevel)
     print(io, "CenterIndexedArray(")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -174,3 +174,14 @@ end
     @test A+A == CenterIndexedArray(dat+dat)
     @test isa(A .+ 1, CenterIndexedArray)
 end
+
+@testset "Interpolations integration" begin
+    y = 1:3
+    yc = CenterIndexedArray(y)
+    itp = interpolate(yc, BSpline(Linear()))
+    @test itp(0.2) ≈ 2.2
+    y = [4.0, 1.0, 0.0, 1.0, 4.0]
+    yc = CenterIndexedArray(y)
+    itp = interpolate!(yc, BSpline(Quadratic(InPlaceQ(OnCell()))))
+    @test itp(0.2) ≈ 0.2^2
+end


### PR DESCRIPTION
This defines `Interpolations.popwrapper` on CenterIndexedArrays,
allowing certain operations to be performed without the caller
having to unwrap the array.