### PR TITLE
Add test for Base.unsafe_indices(::SymRange) to reach 100% coverage

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,7 @@ end
     @test last(r) == 3
     @test axes(r) == (r,)
     @test axes(r, 1) == r
+    @test @inferred(Base.unsafe_indices(r)) === (r,)
     @test size(r) == (7,)
 
     items = []


### PR DESCRIPTION
## Summary

- Adds a direct test for `Base.unsafe_indices(::SymRange)`, the one line missing from coverage
- Brings test coverage from 98.4% → 100%

## Test plan

- [x] `Pkg.test()` passes (20/20 SymRange tests, 140 total)
- [x] Coverage confirmed at 100% via CoverageTools.jl

🤖 Generated with [Claude Code](https://claude.com/claude-code)